### PR TITLE
Added support for self signed proxy ssl certificate

### DIFF
--- a/lib/postmark/http_client.rb
+++ b/lib/postmark/http_client.rb
@@ -5,7 +5,7 @@ module Postmark
   class HttpClient
     attr_accessor :api_token
     attr_reader :http, :secure, :proxy_host, :proxy_port, :proxy_user,
-                :proxy_pass, :host, :port, :path_prefix,
+                :proxy_pass, :proxy_cert, :host, :port, :path_prefix,
                 :http_open_timeout, :http_read_timeout, :http_ssl_version,
                 :auth_header_name
 
@@ -107,6 +107,11 @@ module Postmark
       http.open_timeout = self.http_open_timeout
       http.use_ssl = !!self.secure
       http.ssl_version = self.http_ssl_version if self.http_ssl_version && http.respond_to?(:ssl_version=)
+      if self.proxy_cert
+        store = OpenSSL::X509::Store.new
+        store.add_cert self.proxy_cert
+        http.cert_store = store
+      end
       http
     end
   end


### PR DESCRIPTION
We need to proxy our emails via VGS to de-tokenise the user's email address to send to and any content in the email such as the users name.

Unfortunately VGS uses a self-signed SSL certificate on their proxy server so we need to provide the HTTP client with the certificate to trust. This isn't a native option in the Postmark gem so we need to expose a new option to do that through.

This fork of the gem exposes a `proxy_cert` setting which can take a `OpenSSL::X509::Certificate` instance and use it in the HTTP client to allow the self-signed certificate used by our proxy server.

This is implemented in our Rails app here: https://github.com/ctrlgroup/blackwell-backend/pull/629